### PR TITLE
Setup continuous integration builds for cause

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^output$
 ^gwas_pairs_code$
 ^sim_results$
+^\.travis\.yml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^\.travis\.yml$
 ^appveyor\.yml$
 ^\.circleci/config\.yml$
+^_workflowr\.yml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^sim_results$
 ^\.travis\.yml$
 ^appveyor\.yml$
+^\.circleci/config\.yml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^gwas_pairs_code$
 ^sim_results$
 ^\.travis\.yml$
+^appveyor\.yml$

--- a/.Rprofile
+++ b/.Rprofile
@@ -3,6 +3,4 @@
 if (requireNamespace("workflowr", quietly = TRUE)) {
   message("Loading .Rprofile for the current workflowr project")
   library("workflowr")
-} else {
-  message("workflowr package not installed, please run devtools::install_github('jdblischak/workflowr') to use the workflowr functions")
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: rocker/verse:latest
+    environment:
+      R_LIBS: ~/R/Library
+    steps:
+      - restore_cache:
+          keys:
+            - r-pkg-cache-{{ arch }}-{{ .Branch }}
+            - r-pkg-cache-{{ arch }}-
+      - checkout
+      - run:
+          name: Install package dependencies
+          command: |
+            mkdir -p ~/R/Library
+            Rscript -e 'install.packages("remotes")'
+            Rscript -e 'remotes::install_deps(dependencies = TRUE)'
+      - run:
+          name: Session information and installed package versions
+          command: |
+            Rscript -e 'sessionInfo()'
+            Rscript -e 'installed.packages()[, c("Package", "Version")]'
+            Rscript -e 'rmarkdown::pandoc_version()'
+      - run:
+          name: Build package
+          command: R CMD build .
+      - run:
+          name: Check package
+          command: R CMD check --as-cran --no-manual *tar.gz
+      - store_artifacts:
+          path: cause.Rcheck/
+      - save_cache:
+          key: r-pkg-cache-{{ arch }}-{{ .Branch }}
+          paths:
+            - "~/R/Library"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ language: R
 cache: packages
 os: osx
 latex: false
+warnings_are_errors: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+cache: packages
+os: osx
+latex: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 CAUSE: Causal Analysis Using Summary Effect Estimates
 ======
 
+[![Travis build status](https://travis-ci.com/jean997/cause.svg?branch=master)](https://travis-ci.com/jean997/cause)
+
 This R package implements the CAUSE method described in Morrison et al 2018 (pre-print coming soon).
 
 Get started with an example analysis: https://jean997.github.io/cause/ldl_cad.html

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ CAUSE: Causal Analysis Using Summary Effect Estimates
 ======
 
 [![Travis build status](https://travis-ci.com/jean997/cause.svg?branch=master)](https://travis-ci.com/jean997/cause)
-
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/jean997/cause?branch=master&svg=true)](https://ci.appveyor.com/project/jean997/cause)
+[![CircleCI build status](https://circleci.com/gh/jean997/cause.svg?style=svg)](https://circleci.com/gh/jean997/cause)
 
 This R package implements the CAUSE method described in Morrison et al 2018 (pre-print coming soon).
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ CAUSE: Causal Analysis Using Summary Effect Estimates
 
 [![Travis build status](https://travis-ci.com/jean997/cause.svg?branch=master)](https://travis-ci.com/jean997/cause)
 
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/jean997/cause?branch=master&svg=true)](https://ci.appveyor.com/project/jean997/cause)
+
 This R package implements the CAUSE method described in Morrison et al 2018 (pre-print coming soon).
 
 Get started with an example analysis: https://jean997.github.io/cause/ldl_cad.html

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+environment:
+  NOT_CRAN: true
+  # env vars that may need to be set, at least temporarily, from time to time
+  # see https://github.com/krlmlr/r-appveyor#readme for details
+  # USE_RTOOLS: true
+  # R_REMOTES_STANDALONE: true
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits


### PR DESCRIPTION
I configured the following CI builds:

* Linux on CircleCI
* macOS on Travis CI
* Windows on AppVeyor

I wasn't able to get the builds to install. I removed RcppParallel from NAMESPACE, since that caused `R CMD check` to throw an error.

You can see the build logs at:

https://circleci.com/gh/jdblischak/cause/5
https://travis-ci.com/jdblischak/cause/builds/118972693
https://ci.appveyor.com/project/jdblischak/cause/builds/25942955

Any ideas how I can fix the build? I can run `R CMD build .` on my local Ubuntu, but `R CMD check` fails during the installation check. The file [00install.out](https://5-196615365-gh.circle-artifacts.com/0/root/project/cause.Rcheck/00install.out) contains the following:

```
* installing *source* package ‘cause’ ...
** using staged installation
** libs
g++ -std=gnu++11 -I"/usr/local/lib/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/root/R/Library/RcppParallel/include" -I/usr/local/include  -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c RcppExports.cpp -o RcppExports.o
g++ -std=gnu++11 -I"/usr/local/lib/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/root/R/Library/RcppParallel/include" -I/usr/local/include  -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c log_likelihood_functions.cpp -o log_likelihood_functions.o
g++ -std=gnu++11 -shared -L/usr/local/lib/R/lib -L/usr/local/lib -o cause.so RcppExports.o log_likelihood_functions.o -L/usr/local/lib/R/lib -lR
installing to /root/project/cause.Rcheck/00LOCK-cause/00new/cause/libs
** R
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
Error: package or namespace load failed for ‘cause’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/root/project/cause.Rcheck/00LOCK-cause/00new/cause/libs/cause.so':
  /root/project/cause.Rcheck/00LOCK-cause/00new/cause/libs/cause.so: undefined symbol: _ZTIN3tbb4taskE
Error: loading failed
Execution halted
ERROR: loading failed
* removing ‘/root/project/cause.Rcheck/cause’
```

Note that after you merge this PR, you'll need to activate these 3rd-party services by logging in with your GitHub account.